### PR TITLE
Added title attribute in table header

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -22,7 +22,7 @@ const Table: StatelessFunctionalComponent<Props> = (props) => {
       // default behaviour of asking nested properties via dots
       columns: props.columns.map((c) => ({
         id: c,
-        Header: c,
+        Header: () => <span title={c}>{c}</span>,
         accessor: (d: {[string]: any}) => d[c],
       })),
     },


### PR DESCRIPTION
## Problem:
- Headers were not readable when truncated
- Resizing the last header doesn't work as intuitively
![relational playground 29-jul](https://github.com/user-attachments/assets/0bbba30e-d5a0-4e48-bede-16d3279e09e6)

## Solution:
- Added `title` tag to the headers. Helps with accessibility and shows the value when hovered
![title in relational playground 29-jul ](https://github.com/user-attachments/assets/3c5fc57b-cfbc-40c1-b3b0-c8168408e992)
